### PR TITLE
Fix assumed role session refresh

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -16,7 +16,7 @@ class AWS_Provider:
     def __init__(self, audit_info):
         logger.info("Instantiating aws provider ...")
         self.aws_session = self.set_session(audit_info)
-        self.role_info = audit_info.assumed_role_info
+        self.audit_info = audit_info
 
     def get_session(self):
         return self.aws_session
@@ -62,7 +62,7 @@ class AWS_Provider:
     def refresh(self):
         logger.info("Refreshing assumed credentials...")
 
-        response = assume_role(self.role_info)
+        response = assume_role(self.audit_info)
         refreshed_credentials = dict(
             # Keys of the dict has to be the same as those that are being searched in the parent class
             # https://github.com/boto/botocore/blob/098cc255f81a25b852e1ecdeb7adebd94c7b1b73/botocore/credentials.py#L609


### PR DESCRIPTION
The assume_role function expects the AWS_Audit_Info object as parameter, currently the AWS_Assume_Role object is sent. Currently when the session is refreshed the following error is thrown:
`2022-12-25 17:33:35,036 [File: aws_provider.py:99]      [Module: aws_provider]   CRITICAL: AttributeError -- 'AWS_Assume_Role' object has no attribute 'original_session'`

### Context

Please include relevant motivation and context for this PR.


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
